### PR TITLE
Modal pop-up on back button, goal of modifying add multiple pizzas

### DIFF
--- a/client/pizza-app/src/components/BackButton/BackButton.css
+++ b/client/pizza-app/src/components/BackButton/BackButton.css
@@ -1,0 +1,12 @@
+.alertStyle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.backButtonPositioning {
+  position: absolute;
+  left: 12px;
+  margin-top: 12px;
+  z-index: 1;
+}

--- a/client/pizza-app/src/components/BackButton/BackButton.js
+++ b/client/pizza-app/src/components/BackButton/BackButton.js
@@ -60,8 +60,6 @@ const BackButton = ({ step, previousMenu, prevStep, setMenu, clearPizza }) => {
 
     // Incomplete order on the create pizza page
     step === 3 ? handleShowAlert() : previousMenu();
-
-    // [TODO]: Cart -> Edit Pizza -> clicking "back" should bring the user back to Cart page
   };
 
   // don't display the buttons on home, cart, and confirmation pages

--- a/client/pizza-app/src/components/BackButton/BackButton.js
+++ b/client/pizza-app/src/components/BackButton/BackButton.js
@@ -8,21 +8,48 @@ import StyledButton from '../common/Button/StyledButton';
 import './BackButton.css';
 
 const BackButton = ({ step, previousMenu, prevStep, setMenu, clearPizza }) => {
-  const [goToHome, setGoToHome] = useState(false);
+  /*
+    When the user clicks the "back" button on the create pizza page
+    a modal pop-up appears with options to proceed or stay on the page
+  */
   const [showAlert, setShowAlert] = useState(false);
 
   const handleCloseAlert = () => setShowAlert(false);
-  const handleShowAlert = () => {
-    setShowAlert(true);
-  };
+  const handleShowAlert = () => setShowAlert(true);
 
   const handleGoToHome = () => {
-    setGoToHome(true);
     handleCloseAlert();
     clearPizza();
     previousMenu();
-    setGoToHome(false);
   };
+
+  const renderModal = (
+    <div className="alertStyle">
+      <Modal show={showAlert} onHide={handleCloseAlert}>
+        <Modal.Header closeButton>
+          <Modal.Title>Warning! Your order is incomplete</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>
+            Going to the home page will cause you to lose your pizza order. Do
+            you want to proceed?{' '}
+          </p>
+          <div className="alertStyle">
+            <StyledButton
+              variant="basicButton"
+              text="Proceed"
+              onClick={handleGoToHome}
+            />
+            <StyledButton
+              variant="basicButton"
+              text="Continue Order"
+              onClick={handleCloseAlert}
+            />
+          </div>
+        </Modal.Body>
+      </Modal>
+    </div>
+  );
 
   const handleClick = (evt) => {
     evt.preventDefault();
@@ -37,8 +64,8 @@ const BackButton = ({ step, previousMenu, prevStep, setMenu, clearPizza }) => {
     // [TODO]: Cart -> Edit Pizza -> clicking "back" should bring the user back to Cart page
   };
 
-  // don't display the buttons on home and confirmation pages
-  return step !== 1 && step !== 5 ? (
+  // don't display the buttons on home, cart, and confirmation pages
+  return step !== 1 && step !== 4 && step !== 5 ? (
     <div className="backButtonPositioning">
       <StyledButton
         type="button"
@@ -47,32 +74,7 @@ const BackButton = ({ step, previousMenu, prevStep, setMenu, clearPizza }) => {
         onClick={handleClick}
         text="Back"
       />
-
-      <div className="alertStyle">
-        <Modal show={showAlert} onHide={handleCloseAlert}>
-          <Modal.Header closeButton>
-            <Modal.Title>Warning! Your order is incomplete</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <p>
-              Going to the home page will cause you to lose your pizza order. Do
-              you want to proceed?{' '}
-            </p>
-            <div className="alertStyle">
-              <StyledButton
-                variant="basicButton"
-                text="Proceed"
-                onClick={handleGoToHome}
-              />
-              <StyledButton
-                variant="basicButton"
-                text="Continue Order"
-                onClick={handleCloseAlert}
-              />
-            </div>
-          </Modal.Body>
-        </Modal>
-      </div>
+      {renderModal}
     </div>
   ) : (
     <Fragment />

--- a/client/pizza-app/src/components/BackButton/BackButton.js
+++ b/client/pizza-app/src/components/BackButton/BackButton.js
@@ -1,30 +1,45 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { previousMenu, setMenu } from '../../actions/menu';
 import { clearPizza } from '../../actions/pizza';
-// import { Button } from 'react-bootstrap';
+import { Modal } from 'react-bootstrap';
 import StyledButton from '../common/Button/StyledButton';
+import './BackButton.css';
 
 const BackButton = ({ step, previousMenu, prevStep, setMenu, clearPizza }) => {
+  const [goToHome, setGoToHome] = useState(false);
+  const [showAlert, setShowAlert] = useState(false);
+
+  const handleCloseAlert = () => setShowAlert(false);
+  const handleShowAlert = () => {
+    setShowAlert(true);
+  };
+
+  const handleGoToHome = () => {
+    setGoToHome(true);
+    handleCloseAlert();
+    clearPizza();
+    previousMenu();
+    setGoToHome(false);
+  };
+
   const handleClick = (evt) => {
     evt.preventDefault();
     //clear current pizza
     // clearPizza();
     //when on create pizza, skip order history page
     // (step === 3) ? setMenu(1) : previousMenu();
-    previousMenu();
+
+    // Incomplete order on the create pizza page
+    step === 3 ? handleShowAlert() : previousMenu();
+
+    // [TODO]: Cart -> Edit Pizza -> clicking "back" should bring the user back to Cart page
   };
+
   // don't display the buttons on home and confirmation pages
   return step !== 1 && step !== 5 ? (
-    <div
-      style={{
-        position: 'absolute',
-        left: '12px',
-        marginTop: '12px',
-        zIndex: 9999,
-      }}
-    >
+    <div className="backButtonPositioning">
       <StyledButton
         type="button"
         variant="backButton"
@@ -32,14 +47,32 @@ const BackButton = ({ step, previousMenu, prevStep, setMenu, clearPizza }) => {
         onClick={handleClick}
         text="Back"
       />
-      {/* <Button
-        onClick={handleClick}
-        type="button"
-        variant="primary"
-        disabled={step === 1}
-      >
-        Back
-      </Button> */}
+
+      <div className="alertStyle">
+        <Modal show={showAlert} onHide={handleCloseAlert}>
+          <Modal.Header closeButton>
+            <Modal.Title>Warning! Your order is incomplete</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <p>
+              Going to the home page will cause you to lose your pizza order. Do
+              you want to proceed?{' '}
+            </p>
+            <div className="alertStyle">
+              <StyledButton
+                variant="basicButton"
+                text="Proceed"
+                onClick={handleGoToHome}
+              />
+              <StyledButton
+                variant="basicButton"
+                text="Continue Order"
+                onClick={handleCloseAlert}
+              />
+            </div>
+          </Modal.Body>
+        </Modal>
+      </div>
     </div>
   ) : (
     <Fragment />


### PR DESCRIPTION
WIP

Goal: when the user has multiple pizzas in the Cart, the only way they can add another pizza is by clicking the "add another pizza" button. Currently, clicking the back button in the Cart page will bring them to the CreatePizza page and add another pizza this way-- hoping to change this.

first commit: setting up Modal pop-up on the Back button. When the user is on the CreatePizza page and click back, they get a pop-up warning that they can lose their current order, with options to retain the order or lose it and go back to the Home page. 